### PR TITLE
Remove strange text from server-subversion.svg

### DIFF
--- a/tango/scalable/devices/server-subversion.svg
+++ b/tango/scalable/devices/server-subversion.svg
@@ -3932,7 +3932,6 @@
         </g>
         <path id="path5417" d="M 147.59256,358.81339 C 147.59256,475.15164 147.59256,591.4899 147.59256,707.82815 C 281.19403,707.82815 414.79553,707.82815 548.39699,707.82815 C 548.39699,590.77685 548.39699,473.72554 548.39699,356.67424 C 414.79553,356.67424 281.19403,356.67424 147.59256,356.67424 L 147.59256,357.74382 L 147.59256,358.81339 z" style="fill:url(#linearGradient11894);fill-opacity:1;stroke:#d3d7cf;stroke-width:19.52175713;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
       </g>
-      <text y="312.69955" xml:space="preserve" x="-1375.7275" style="font-size:12px;font-style:normal;font-weight:normal;fill:#000000;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans" id="text2684"><tspan y="312.69955" x="-1375.7275" sodipodi:role="line" id="tspan2686"></tspan></text>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
There is a strange character far to the left of the image. Inkscape does not see it, but yEd does causing a big white area left of the image. This commit removes the text.
